### PR TITLE
Setting target states in problem definition

### DIFF
--- a/qpmpc/mpc_problem.py
+++ b/qpmpc/mpc_problem.py
@@ -137,6 +137,8 @@ class MPCProblem:
             self.update_goal_state(goal_state)
         if initial_state is not None:
             self.update_initial_state(initial_state)
+        if target_states is not None:
+            self.update_target_states(target_states)
 
     @property
     def has_terminal_cost(self) -> bool:


### PR DESCRIPTION
Hello !
The target states were not set in the initialization of the MPC problem. 
More precisely, the method ```update_target_states``` was already implemented, but never called. This led the stage state cost to have no effect.